### PR TITLE
Update to run on rust nightly 1.15.0

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(duration_span)]
-
 #[macro_use]
 extern crate log;
 
@@ -9,7 +7,7 @@ extern crate linenoise;
 extern crate llamadb;
 
 use std::io::Write;
-use std::time::Duration;
+use std::time::Instant;
 
 mod prettyselect;
 use prettyselect::pretty_select;
@@ -82,12 +80,10 @@ fn execute_statement(out: &mut Write, db: &mut llamadb::tempdb::TempDb, statemen
 {
     use llamadb::tempdb::ExecuteStatementResponse;
 
-    let mut execute_result = None;
+    let now = Instant::now();
+    let execute_result = Some(db.execute_statement(statement));
+    let duration = now.elapsed();
 
-    let duration = Duration::span(|| {
-        execute_result = Some(db.execute_statement(statement));
-    });
-    
     let seconds = duration.as_secs() as f32 + (duration.subsec_nanos() as f32 * 1.0e-9);
 
     let duration_string = format!("{:.3}s", seconds);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(into_cow, associated_type_defaults)]
+#![feature(associated_type_defaults)]
 
 #[macro_use]
 extern crate log;

--- a/src/queryplan/execute/groupbuckets.rs
+++ b/src/queryplan/execute/groupbuckets.rs
@@ -62,9 +62,10 @@ impl<ColumnValue: Clone + Eq + Hash + 'static> Group for GroupBucket<ColumnValue
     type ColumnValue = ColumnValue;
 
     fn get_any_row<'b>(&'b self) -> Option<Cow<'b, [ColumnValue]>> {
-        use std::borrow::IntoCow;
-
-        self.rows.iter().nth(0).map(|r| r.into_cow())
+        self.rows.iter().nth(0).map(|row| {
+            let row_ref: &[ColumnValue] = &row;
+            Cow::Borrowed(row_ref)
+        })
     }
 
     fn count(&self) -> u64 {
@@ -73,10 +74,8 @@ impl<ColumnValue: Clone + Eq + Hash + 'static> Group for GroupBucket<ColumnValue
 
     fn iter<'a>(&'a self) -> Box<Iterator<Item=Cow<'a, [ColumnValue]>> + 'a> {
         Box::new(self.rows.iter().map(|row| {
-            use std::borrow::IntoCow;
-
             let row_ref: &[ColumnValue] = &row;
-            row_ref.into_cow()
+            Cow::Borrowed(row_ref)
         }))
     }
 }

--- a/src/queryplan/mod.rs
+++ b/src/queryplan/mod.rs
@@ -663,7 +663,7 @@ where DB: 'a, <DB as DatabaseInfo>::Table: 'a
         groups_info: &mut GroupsInfo)
     -> Result<SExpression<'a, DB>, QueryPlanCompileError>
     {
-        use std::borrow::IntoCow;
+        use std::borrow::Cow;
 
         match ast {
             ast::Expression::Ident(s) => {
@@ -718,13 +718,13 @@ where DB: 'a, <DB as DatabaseInfo>::Table: 'a
                 })
             },
             ast::Expression::StringLiteral(s) => {
-                match DB::ColumnValue::from_string_literal(s.into_cow()) {
+                match DB::ColumnValue::from_string_literal(Cow::Borrowed(&s)) {
                     Ok(value) => Ok(SExpression::Value(value)),
                     Err(s) => Err(QueryPlanCompileError::BadStringLiteral(s.into_owned()))
                 }
             },
             ast::Expression::Number(s) => {
-                match DB::ColumnValue::from_number_literal(s.into_cow()) {
+                match DB::ColumnValue::from_number_literal(Cow::Borrowed(&s)) {
                     Ok(value) => Ok(SExpression::Value(value)),
                     Err(s) => Err(QueryPlanCompileError::BadNumberLiteral(s.into_owned()))
                 }

--- a/src/tempdb/mod.rs
+++ b/src/tempdb/mod.rs
@@ -63,7 +63,7 @@ impl<'a> Group for ScanGroup<'a> {
 
         Box::new(table.rowid_index.iter().map(move |key_v| {
             use byteutils;
-            use std::borrow::IntoCow;
+            use std::borrow::Cow;
 
             let raw_key: &[u8] = &key_v;
             trace!("KEY: {:?}", raw_key);
@@ -108,13 +108,13 @@ impl<'a> Group for ScanGroup<'a> {
                     let bytes = &raw_key[key_offset..key_offset + size];
 
                     trace!("from bytes: {:?}, {:?}", column.dbtype, bytes);
-                    let value = ColumnValueOps::from_bytes(column.dbtype, bytes.into_cow()).unwrap();
+                    let value = ColumnValueOps::from_bytes(column.dbtype, Cow::Borrowed(bytes)).unwrap();
                     key_offset += size;
                     value
                 }
             }).collect();
 
-            v.into_cow()
+            Cow::Owned(v)
         }))
     }
 }

--- a/src/types/variant.rs
+++ b/src/types/variant.rs
@@ -2,7 +2,7 @@ use byteutils;
 use columnvalueops::ColumnValueOps;
 use types::DbType;
 use types::F64NoNaN;
-use std::borrow::{Cow, IntoCow};
+use std::borrow::Cow;
 use std::fmt;
 
 #[derive(Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
@@ -215,7 +215,7 @@ impl ColumnValueOps for Variant {
             (Variant::Bytes(bytes), v) => {
                 // every variant can be converted from their byte representation
                 let r: &[u8] = &bytes;
-                match ColumnValueOps::from_bytes(v, r.into_cow()) {
+                match ColumnValueOps::from_bytes(v, Cow::Borrowed(r)) {
                     Ok(s) => Some(s),
                     Err(()) => None
                 }


### PR DESCRIPTION
llamadb is broken in the current rust nightly 1.15.0 release. 

The first change is using the `Cow::` smart pointer constructor instead of `into_cow`, since [it has been depreciated](https://github.com/rust-lang/rust/issues/27735). The other change is to the `time::Duration` module, where [span was depreciated](https://github.com/rust-lang/rust/issues/27799). The idiomatic way to time a function is to use `Instant::now()` with the corresponding `elapsed()` function.